### PR TITLE
docs: remove outdated deprecation notices from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-**NOTE: This repository is no longer supported or updated by GitHub. If you wish to continue to develop this code yourself, we recommend you fork it.**
 
 # Albino: a ruby wrapper for pygmentize
 


### PR DESCRIPTION
Remove obsolete deprecation banners to clean up library description text.